### PR TITLE
Add vm tags from api to returned object

### DIFF
--- a/library/Pve/Api.php
+++ b/library/Pve/Api.php
@@ -226,6 +226,7 @@ class Api
                 "vm_type" => $el['type'],
                 "hardware_cpu" => (int) $el['maxcpu'],
                 "hardware_memory" => (int) $el['maxmem'] / 1024 * 1024,
+                "tags" => $el['tags'] ?? "",
             ];
 
             if (isset($el['pool'])) {


### PR DESCRIPTION
Fixes: #23

I have gone ahead and added this simple implementation. An empty string was chosen as a default value to allow for me to use a RegexSplit modifier with the option to leave an empty array in case the string is empty.

The quality of life features proposed in the issue are not present here tho they can be added by someone else should they wish to.

Cheers,
Niko 