### PR TITLE
Fix storage import failing on missing maxdisk field

### DIFF
--- a/library/Pve/Api.php
+++ b/library/Pve/Api.php
@@ -169,7 +169,7 @@ class Api
                 "shared" => (int) ($storage["shared"] ?? 0) === 1,
                 "node" => $storage["node"],
                 "type" => $storage["type"],
-                "capacity" => $storage["maxdisk"],
+                "capacity" => $storage["maxdisk"] ?? null,
             ];
 
         }


### PR DESCRIPTION
Fixes #26

On PVE 9 the storage entries from /cluster/resources can come back without a maxdisk field, which makes the whole import source fail with "Undefined array key". Fall back to null for the capacity column in that case, same as the existing fallback for shared.